### PR TITLE
Cambiado tiempo de expiración a minutos

### DIFF
--- a/Cache.php
+++ b/Cache.php
@@ -16,8 +16,8 @@ class Cache {
 	 */
 	public static $config = array(
 		'cache_dir' => 'cache',
-		// Default expiration time in *hours*
-		'expires' => 3
+		// Default expiration time in *minutes*
+		'expires' => 180,
 	);
 
 	/**
@@ -25,14 +25,14 @@ class Cache {
 	 *
 	 * <code>
 	 * Cache::configure(array(
-	 *   'expires' => 3,
+	 *   'expires' => 180,
 	 *   'cache_path' => 'cache'
 	 * ));
 	 * </code>
 	 * Or passing a key/val:
 	 *
 	 * <code>
-	 * Cache::configure('expires', 3);
+	 * Cache::configure('expires', 180);
 	 * </code>
 	 *
 	 * @access public
@@ -125,13 +125,13 @@ class Cache {
 	 *
 	 * @access public
 	 * @param $file the rout to the file
-	 * @param int $time the number of hours it was set to expire
+	 * @param int $time the number of minutes it was set to expire
 	 * @return bool if the file has expired or not
 	 */
 	public static function file_expired($file, $time = null) {
 		if( ! file_exists($file) ) {
 			return true;
 		}
-		return (time() > (filemtime($file) + 60 * 60 * ($time ? $time : self::$config['expires'])));
+		return (time() > (filemtime($file) + 60 * ($time ? $time : self::$config['expires'])));
 	}
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ require 'Cache.php';
 Hay dos opciones: `cache_dir` y `expires`.
 
 * `cache_dir` es el directorio donde se almacenará la caché. Por defecto es un directorio relativo (`cache`)
-* `expires` es el tiempo *en horas* que debe de pasar para que un item de la caché expire
+* `expires` es el tiempo *en minutos* que debe de pasar para que un item de la caché expire
 
 **Importante**: Verifica que el archivo configurado como `cache_dir` tenga permisos de escritura. Además, **si almacenas datos que no deberían ser accesibles públicamente, tu directorio `cache_dir` debería de tener un archivo `.htaccess` con la siguiente línea:**
 ```

--- a/test.php
+++ b/test.php
@@ -16,7 +16,7 @@ echo "<pre>";
 
 Cache::configure(array(
 	'cache_path' => dirname(__FILE__) . '/cache',
-	'expires' => 3
+	'expires' => 180
 ));
 
 function get_rand_key() {


### PR DESCRIPTION
He modificado el control del tiempo de expiración para medirse en
minutos en vez de en horas.
He actualizado la configuración por defecto y las referencias en los
demás archivos del proyecto.

He hecho este cambio porque me hacía falta para mi proyecto, necesito un tiempo de expiración de pocos minutos, y así de esta forma se le añade más flexibilidad a la configuración.
Hago el pull request por si te interesa adoptar el cambio, pero entiendo si prefieres no hacerlo. De todos modos lo dejaré en minutos en mi fork. No he tocado el número de versión por respetar tus decisiones de nomenclatura, pero con este cambio quizá sería conveniente incrementarlo ya que cambia la "api pública".

En cualquier caso, gracias por el script. Me has ahorrado una tarde peleándome con PHP ;)
